### PR TITLE
Multiple additions and bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Written for Darwin Tree of Life chromosomal level genome assemblies. The executa
 - GC content
 - GC proportion
 - GC and AT skew
-- Proportion of G's, C's, A's, T's, N's
+- Proportion of G's, C's, A's, T's, N's, and CpG's
 - Shannon entropy
 - Di/tri/tetranucleotide shannon diversity
 - Di/tri/tetranucleotide frequency arrays
@@ -66,16 +66,16 @@ The default window size is 1kb.
 Output is now a tsv with bed-like format in the first three columns:
 
 ```
-ID      start   end     GC_prop GC_skew Shannon_entropy Prop_Gs Prop_Cs Prop_As Prop_Ts Prop_Ns Dinucleotide_Shannon_false      Trinucleotide_Shannon_false Tetranucleotide_Shannon_false
-SUPER_1 0       1000    0.452   -0.270  1.929   0.165   0.287   0.361   0.187   0       2.646   3.929   5.134
-SUPER_1 1000    2000    0.34    -0.335  1.896   0.113   0.227   0.346   0.314   0       2.617   3.872   5.015
-SUPER_1 2000    3000    0.388   -0.912  1.627   0.017   0.371   0.407   0.205   0       1.858   2.049   2.096
-SUPER_1 3000    4000    0.634   -0.167  1.933   0.264   0.37    0.199   0.167   0       2.671   3.980   5.215
-SUPER_1 4000    5000    0.591   -0.184  1.954   0.241   0.35    0.236   0.173   0       2.701   4.020   5.232
-SUPER_1 5000    6000    0.599   -0.229  1.948   0.231   0.368   0.212   0.189   0       2.679   3.991   5.209
-SUPER_1 6000    7000    0.596   -0.164  1.961   0.249   0.347   0.214   0.19    0       2.694   3.994   5.206
-SUPER_1 7000    8000    0.602   -0.193  1.950   0.243   0.359   0.178   0.22    0       2.672   3.974   5.184
-SUPER_1 8000    9000    0.453   -0.214  1.977   0.178   0.275   0.292   0.255   0       2.725   4.031   5.237
+ID	start	end	GC_prop	GC_skew	AT_skew	Shannon_entropy	Prop_Gs	Prop_Cs	Prop_As	Prop_Ts	Prop_Ns	CpG_prop	Dinucleotide_Shannon	Trinucleotide_Shannon	Tetranucleotide_Shannon
+OV656674.1	0	1000	0.533	-0.088	-0.006	1.994	0.243	0.290	0.232	0.235	0.000	0.070	3.963	5.825	7.474
+OV656674.1	1000	2000	0.645	0.048	0.025	1.937	0.338	0.307	0.182	0.173	0.000	0.120	3.862	5.751	7.526
+OV656674.1	2000	3000	0.579	0.022	0.012	1.982	0.296	0.283	0.213	0.208	0.000	0.106	3.940	5.871	7.653
+OV656674.1	3000	4000	0.541	0.039	-0.020	1.994	0.281	0.260	0.225	0.234	0.000	0.081	3.980	5.926	7.763
+OV656674.1	4000	5000	0.585	0.084	-0.075	1.974	0.317	0.268	0.192	0.223	0.000	0.104	3.917	5.801	7.568
+OV656674.1	5000	6000	0.529	-0.096	-0.006	1.994	0.239	0.290	0.234	0.237	0.000	0.068	3.938	5.740	7.297
+OV656674.1	6000	7000	0.576	-0.118	0.075	1.976	0.254	0.322	0.228	0.196	0.000	0.079	3.948	5.884	7.666
+OV656674.1	7000	8000	0.526	-0.004	0.084	1.996	0.262	0.264	0.257	0.217	0.000	0.065	3.975	5.903	7.692
+OV656674.1	8000	9000	0.430	-0.093	0.088	1.980	0.195	0.235	0.310	0.260	0.000	0.054	3.955	5.899	7.719
 ```
 
 Also output (non-optional at the moment), are three more TSV's, which are the arrays of di/tri/tetranucleotide frequencies in each window. These files are large, especially as tetranucleotide frequencies will contain 4e4 columns. The kmers are sorted lexicographically from left -> right (AA(AA) to TT(TT)).
@@ -84,22 +84,21 @@ e.g. for dinucleotide frequencies:
 
 ```
 ID	start	end	AA	AC	AG	AT	CA	CC	CG	CT	GA	GC	GG	GT	TA	TC	TG	TT
-SUPER_1 0       1000    122     120     45      73      134     68      39      46      50      55      45      15      54      44 36       53
-SUPER_1 1000    2000    140     83      32      90      85      54      22      66      30      25      19      39      91      65 40       118
-SUPER_1 2000    3000    216     181     4       5       4       181     5       181     3       8       3       3       183     1  516
-SUPER_1 3000    4000    40      61      54      44      80      137     86      66      54      99      76      35      24      73 48       22
-SUPER_1 4000    5000    55      68      75      38      88      138     66      57      58      78      59      46      35      65 41       32
-SUPER_1 5000    6000    32      71      63      46      85      137     71      75      65      66      65      34      30      94 31       34
-SUPER_1 6000    7000    47      62      63      42      91      132     60      64      58      84      74      32      18      69 51       52
-SUPER_1 7000    8000    29      49      64      35      67      143     52      97      58      82      72      31      24      85 55       56
-SUPER_1 8000    9000    114     67      43      68      63      86      52      73      51      49      43      35      64      73 40       78
-SUPER_1 9000    10000   97      97      44      63      72      95      50      67      46      44      33      46      85      49 42       69
+OV656674.1	0	1000	74	65	47	46	38	99	70	83	58	65	68	52	62	60	58	54
+OV656674.1	1000	2000	36	54	58	33	49	89	120	49	75	101	97	65	22	63	62	26
+OV656674.1	2000	3000	62	46	68	37	45	74	106	58	64	93	67	71	41	70	55	42
+OV656674.1	3000	4000	55	56	55	59	61	59	81	58	70	73	72	66	39	71	73	51
+OV656674.1	4000	5000	35	58	45	54	46	53	104	64	83	87	80	67	28	70	87	38
+OV656674.1	5000	6000	81	71	42	40	29	106	68	87	56	60	71	51	68	53	58	58
+OV656674.1	6000	7000	57	74	58	39	78	96	79	68	56	87	64	47	37	64	53	42
+OV656674.1	7000	8000	81	45	79	52	63	74	65	62	69	82	59	52	44	62	59	51
+OV656674.1	8000	9000	103	71	49	87	70	57	54	54	59	44	40	51	78	62	52	68
 ```
 
 ### Comments, updates & bugs
 
 As of version 0.2.2, I've removed canonical kmers as an option; it was really computationally expensive and I couldn't think of a way to efficienty add it in. End users that wish this are pointed in the direction of <a href="https://github.com/tolkit/fw_group">fw_group</a>, which will at some point soon provide this functionality.
 
-The masked (-m) flag only affects GC content, GC proportion, GC and AT skew, proportion of G's, C's, A's, T's, N's. Kmers are coerced to uppercase automatically. Shannon index counts only uppercase nucleotides.
+The masked (-m) flag only affects GC content, GC proportion, GC and AT skew, proportion of G's, C's, A's, T's, N's, CpG's. Kmers are coerced to uppercase automatically. Shannon index counts only uppercase nucleotides.
 
 Please use, test, and let me know if there are any bugs or features you want implemented. Either raise an issue, or email me (see email in usage).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Written for Darwin Tree of Life chromosomal level genome assemblies. The executa
 
 - GC content
 - GC proportion
-- GC skew
+- GC and AT skew
 - Proportion of G's, C's, A's, T's, N's
 - Shannon entropy
 - Di/tri/tetranucleotide shannon diversity
@@ -100,6 +100,6 @@ SUPER_1 9000    10000   97      97      44      63      72      95      50      
 
 As of version 0.2.2, I've removed canonical kmers as an option; it was really computationally expensive and I couldn't think of a way to efficienty add it in. End users that wish this are pointed in the direction of <a href="https://github.com/tolkit/fw_group">fw_group</a>, which will at some point soon provide this functionality.
 
-The masked (-m) flag only affects GC content, GC proportion, GC skew, proportion of G's, C's, A's, T's, N's. Kmers are coerced to uppercase automatically. Shannon index counts only uppercase nucleotides.
+The masked (-m) flag only affects GC content, GC proportion, GC and AT skew, proportion of G's, C's, A's, T's, N's. Kmers are coerced to uppercase automatically. Shannon index counts only uppercase nucleotides.
 
 Please use, test, and let me know if there are any bugs or features you want implemented. Either raise an issue, or email me (see email in usage).

--- a/src/fw.rs
+++ b/src/fw.rs
@@ -92,6 +92,7 @@ pub fn fasta_windows(
                     end,
                     gc_proportion: seq_stats.gc_proportion,
                     gc_skew: seq_stats.gc_skew,
+                    at_skew: seq_stats.at_skew,
                     shannon_entropy: seq_stats.shannon_entropy,
                     g_s: seq_stats.g_s,
                     c_s: seq_stats.c_s,
@@ -157,6 +158,7 @@ pub struct Entry {
     pub end: usize,
     pub gc_proportion: f32,
     pub gc_skew: f32,
+    pub at_skew: f32,
     pub shannon_entropy: f64,
     pub g_s: f32,
     pub c_s: f32,
@@ -183,8 +185,8 @@ impl Output {
         let header;
 
         match description {
-            true => header = "ID\tdescription\tstart\tend\tGC_prop\tGC_skew\tShannon_entropy\tProp_Gs\tProp_Cs\tProp_As\tProp_Ts\tProp_Ns\tDinucleotide_Shannon\tTrinucleotide_Shannon\tTetranucleotide_Shannon".to_string(),
-            false => header = "ID\tstart\tend\tGC_prop\tGC_skew\tShannon_entropy\tProp_Gs\tProp_Cs\tProp_As\tProp_Ts\tProp_Ns\tDinucleotide_Shannon\tTrinucleotide_Shannon\tTetranucleotide_Shannon".to_string()
+            true => header = "ID\tdescription\tstart\tend\tGC_prop\tGC_skew\tAT_skew\tShannon_entropy\tProp_Gs\tProp_Cs\tProp_As\tProp_Ts\tProp_Ns\tDinucleotide_Shannon\tTrinucleotide_Shannon\tTetranucleotide_Shannon".to_string(),
+            false => header = "ID\tstart\tend\tGC_prop\tGC_skew\tAT_skew\tShannon_entropy\tProp_Gs\tProp_Cs\tProp_As\tProp_Ts\tProp_Ns\tDinucleotide_Shannon\tTrinucleotide_Shannon\tTetranucleotide_Shannon".to_string()
         }
 
         writeln!(file, "{}", header)
@@ -195,13 +197,14 @@ impl Output {
                 for i in &self.0 {
                     writeln!(
                         file,
-                        "{}\t{}\t{}\t{}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}",
+                        "{}\t{}\t{}\t{}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}",
                         i.id,
                         i.desc,
                         i.start,
                         i.end,
                         i.gc_proportion,
                         i.gc_skew,
+                        i.at_skew,
                         i.shannon_entropy,
                         i.g_s,
                         i.c_s,
@@ -220,12 +223,13 @@ impl Output {
                 for i in &self.0 {
                     writeln!(
                         file,
-                        "{}\t{}\t{}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}",
+                        "{}\t{}\t{}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}",
                         i.id,
                         i.start,
                         i.end,
                         i.gc_proportion,
                         i.gc_skew,
+                        i.at_skew,
                         i.shannon_entropy,
                         i.g_s,
                         i.c_s,

--- a/src/fw.rs
+++ b/src/fw.rs
@@ -294,7 +294,7 @@ impl Output {
                 for i in &self.0 {
                     let desc = match description {
                         true => format!("{}\t", i.desc),
-                        false => format!("\t"),
+                        false => format!(""),
                     };
                     writeln!(
                         file1,

--- a/src/fw.rs
+++ b/src/fw.rs
@@ -192,59 +192,34 @@ impl Output {
         writeln!(file, "{}", header)
             .unwrap_or_else(|_| eprintln!("[-]\tError in writing to file."));
 
-        match description {
-            true => {
-                for i in &self.0 {
-                    writeln!(
-                        file,
-                        "{}\t{}\t{}\t{}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}",
-                        i.id,
-                        i.desc,
-                        i.start,
-                        i.end,
-                        i.gc_proportion,
-                        i.gc_skew,
-                        i.at_skew,
-                        i.shannon_entropy,
-                        i.g_s,
-                        i.c_s,
-                        i.a_s,
-                        i.t_s,
-                        i.n_s,
-                        i.dinucleotides,
-                        i.trinucleotides,
-                        i.tetranucleotides,
-                    )
-                    .unwrap_or_else(|_| eprintln!("[-]\tError in writing to file."));
-                }
-                file.flush().unwrap();
-            }
-            false => {
-                for i in &self.0 {
-                    writeln!(
-                        file,
-                        "{}\t{}\t{}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}",
-                        i.id,
-                        i.start,
-                        i.end,
-                        i.gc_proportion,
-                        i.gc_skew,
-                        i.at_skew,
-                        i.shannon_entropy,
-                        i.g_s,
-                        i.c_s,
-                        i.a_s,
-                        i.t_s,
-                        i.n_s,
-                        i.dinucleotides,
-                        i.trinucleotides,
-                        i.tetranucleotides,
-                    )
-                    .unwrap_or_else(|_| eprintln!("[-]\tError in writing to file."));
-                }
-                file.flush().unwrap();
-            }
+        for i in &self.0 {
+            let desc = match description {
+                true => format!("{}\t", i.desc),
+                false => format!(""),
+            };
+            writeln!(
+                file,
+                "{}\t{}{}\t{}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}",
+                i.id,
+                desc,
+                i.start,
+                i.end,
+                i.gc_proportion,
+                i.gc_skew,
+                i.at_skew,
+                i.shannon_entropy,
+                i.g_s,
+                i.c_s,
+                i.a_s,
+                i.t_s,
+                i.n_s,
+                i.dinucleotides,
+                i.trinucleotides,
+                i.tetranucleotides,
+            )
+            .unwrap_or_else(|_| eprintln!("[-]\tError in writing to file."));
         }
+        file.flush().unwrap();
 
         Ok(())
     }

--- a/src/fw.rs
+++ b/src/fw.rs
@@ -101,6 +101,7 @@ pub fn fasta_windows(
                     a_s: seq_stats.a_s,
                     t_s: seq_stats.t_s,
                     n_s: seq_stats.n_s,
+                    cpg_s: ((*kmer_stats.di_freq.get(6).unwrap_or(&0) as f32) / seq_stats.len),
                     dinucleotides: kmer_stats.dinucleotides,
                     trinucleotides: kmer_stats.trinucleotides,
                     tetranucleotides: kmer_stats.tetranucleotides,
@@ -169,6 +170,7 @@ pub struct Entry {
     pub a_s: f32,
     pub t_s: f32,
     pub n_s: f32,
+    pub cpg_s: f32,
     pub dinucleotides: f64,
     pub trinucleotides: f64,
     pub tetranucleotides: f64,
@@ -189,8 +191,8 @@ impl Output {
         let header;
 
         match description {
-            true => header = "ID\tdescription\tstart\tend\tGC_prop\tGC_skew\tAT_skew\tShannon_entropy\tProp_Gs\tProp_Cs\tProp_As\tProp_Ts\tProp_Ns\tDinucleotide_Shannon\tTrinucleotide_Shannon\tTetranucleotide_Shannon".to_string(),
-            false => header = "ID\tstart\tend\tGC_prop\tGC_skew\tAT_skew\tShannon_entropy\tProp_Gs\tProp_Cs\tProp_As\tProp_Ts\tProp_Ns\tDinucleotide_Shannon\tTrinucleotide_Shannon\tTetranucleotide_Shannon".to_string()
+            true => header = "ID\tdescription\tstart\tend\tGC_prop\tGC_skew\tAT_skew\tShannon_entropy\tProp_Gs\tProp_Cs\tProp_As\tProp_Ts\tProp_Ns\tCpG_prop\tDinucleotide_Shannon\tTrinucleotide_Shannon\tTetranucleotide_Shannon".to_string(),
+            false => header = "ID\tstart\tend\tGC_prop\tGC_skew\tAT_skew\tShannon_entropy\tProp_Gs\tProp_Cs\tProp_As\tProp_Ts\tProp_Ns\tCpG_prop\tDinucleotide_Shannon\tTrinucleotide_Shannon\tTetranucleotide_Shannon".to_string()
         }
 
         writeln!(file, "{}", header)
@@ -203,7 +205,7 @@ impl Output {
             };
             writeln!(
                 file,
-                "{}\t{}{}\t{}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}",
+                "{}\t{}{}\t{}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}",
                 i.id,
                 desc,
                 i.start,
@@ -217,6 +219,7 @@ impl Output {
                 i.a_s,
                 i.t_s,
                 i.n_s,
+                i.cpg_s,
                 i.dinucleotides,
                 i.trinucleotides,
                 i.tetranucleotides,

--- a/src/fw.rs
+++ b/src/fw.rs
@@ -13,7 +13,7 @@ use std::sync::mpsc::channel;
 
 pub fn fasta_windows(
     matches: &clap::ArgMatches,
-    mut window_file: BufWriter<File>,
+    mut window_file_0: BufWriter<File>,
     mut window_file_2: BufWriter<File>,
     mut window_file_3: BufWriter<File>,
     mut window_file_4: BufWriter<File>,
@@ -136,7 +136,7 @@ pub fn fasta_windows(
 
     eprintln!("[+]\tWriting output to files");
 
-    entry_writer.write_windows(&mut window_file, description)?;
+    entry_writer.write_windows(&mut window_file_0, description)?;
     entry_writer.write_kmers(
         &mut window_file_2,
         &mut window_file_3,
@@ -226,9 +226,9 @@ impl Output {
 
     pub fn write_kmers(
         &mut self,
-        file1: &mut BufWriter<File>,
         file2: &mut BufWriter<File>,
         file3: &mut BufWriter<File>,
+        file4: &mut BufWriter<File>,
         kmer_maps: Vec<KmerMap>,
         description: bool,
     ) -> std::io::Result<()> {
@@ -236,34 +236,33 @@ impl Output {
         // unpack kmer_maps
         match kmer_maps.as_slice() {
             [two, three, four] => {
-                // headers for dinucs
-                let mut dinuc_headers = Vec::new();
+                // headers for all
                 let header: String;
-
                 match description {
                     true => header = "ID\tdescription\tstart\tend\t".to_string(),
                     false => header = "ID\tstart\tend\t".to_string(),
                 }
 
                 // headers for dinucs
+                let mut dinuc_headers = Vec::new();
                 for key in two.map.keys().sorted() {
                     dinuc_headers.push(key)
                 }
-                writeln!(file1, "{}{}", header, WriteKmerValues(dinuc_headers))
+                writeln!(file2, "{}{}", header, WriteKmerValues(dinuc_headers))
                     .unwrap_or_else(|_| eprintln!("[-]\tError in writing to file."));
                 // headers for trinucs
                 let mut trinuc_headers = Vec::new();
                 for key in three.map.keys().sorted() {
                     trinuc_headers.push(key)
                 }
-                writeln!(file2, "{}{}", header, WriteKmerValues(trinuc_headers))
+                writeln!(file3, "{}{}", header, WriteKmerValues(trinuc_headers))
                     .unwrap_or_else(|_| eprintln!("[-]\tError in writing to file."));
                 // headers for tetranucs
                 let mut tetranuc_headers = Vec::new();
                 for key in four.map.keys().sorted() {
                     tetranuc_headers.push(key)
                 }
-                writeln!(file3, "{}{}", header, WriteKmerValues(tetranuc_headers))
+                writeln!(file4, "{}{}", header, WriteKmerValues(tetranuc_headers))
                     .unwrap_or_else(|_| eprintln!("[-]\tError in writing to file."));
 
                 for i in &self.0 {
@@ -272,7 +271,7 @@ impl Output {
                         false => format!(""),
                     };
                     writeln!(
-                        file1,
+                        file2,
                         "{}\t{}{}\t{}\t{}",
                         i.id,
                         desc,
@@ -283,7 +282,7 @@ impl Output {
                     .unwrap_or_else(|_| eprintln!("[-]\tError in writing to file."));
 
                     writeln!(
-                        file2,
+                        file3,
                         "{}\t{}{}\t{}\t{}",
                         i.id,
                         desc,
@@ -294,7 +293,7 @@ impl Output {
                     .unwrap_or_else(|_| eprintln!("[-]\tError in writing to file."));
 
                     writeln!(
-                        file3,
+                        file4,
                         "{}\t{}{}\t{}\t{}",
                         i.id,
                         desc,
@@ -305,9 +304,9 @@ impl Output {
                     .unwrap_or_else(|_| eprintln!("[-]\tError in writing to file."));
                 }
 
-                file1.flush().unwrap();
                 file2.flush().unwrap();
                 file3.flush().unwrap();
+                file4.flush().unwrap();
             }
             [..] => {} // Make the patterns exhaustive
         }

--- a/src/fw.rs
+++ b/src/fw.rs
@@ -249,7 +249,7 @@ impl Output {
                 }
 
                 // headers for mononucs
-                writeln!(file1, "{}A\tC\tG\tT", header)
+                writeln!(file1, "{}A\tC\tG\tT\tN", header)
                     .unwrap_or_else(|_| eprintln!("[-]\tError in writing to file."));
                 // headers for dinucs
                 let mut dinuc_headers = Vec::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,6 +67,10 @@ fn main() -> std::io::Result<()> {
     let window_file_0 = File::create(&output_file_0).unwrap();
     let window_file_0 = BufWriter::new(window_file_0);
 
+    let output_file_1 = format!("./fw_out/{}{}", output, "_mononuc_windows.tsv");
+    let window_file_1 = File::create(&output_file_1).unwrap();
+    let window_file_1 = BufWriter::new(window_file_1);
+
     let output_file_2 = format!("./fw_out/{}{}", output, "_dinuc_windows.tsv");
     let window_file_2 = File::create(&output_file_2).unwrap();
     let window_file_2 = BufWriter::new(window_file_2);
@@ -83,6 +87,7 @@ fn main() -> std::io::Result<()> {
     fasta_windows(
         &matches,
         window_file_0,
+        window_file_1,
         window_file_2,
         window_file_3,
         window_file_4,

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,9 +63,9 @@ fn main() -> std::io::Result<()> {
     }
 
     // initiate the output TSV files
-    let output_file_1 = format!("./fw_out/{}{}", output, "_windows.tsv");
-    let window_file = File::create(&output_file_1).unwrap();
-    let window_file = BufWriter::new(window_file);
+    let output_file_0 = format!("./fw_out/{}{}", output, "_freq_windows.tsv");
+    let window_file_0 = File::create(&output_file_0).unwrap();
+    let window_file_0 = BufWriter::new(window_file_0);
 
     let output_file_2 = format!("./fw_out/{}{}", output, "_dinuc_windows.tsv");
     let window_file_2 = File::create(&output_file_2).unwrap();
@@ -82,7 +82,7 @@ fn main() -> std::io::Result<()> {
     // pass this function the matches from clap && the four files to write.
     fasta_windows(
         &matches,
-        window_file,
+        window_file_0,
         window_file_2,
         window_file_3,
         window_file_4,

--- a/src/seq_statsu8.rs
+++ b/src/seq_statsu8.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 pub struct SeqStats {
     pub gc_proportion: f32,
     pub gc_skew: f32,
+    pub at_skew: f32,
     pub shannon_entropy: f64,
     // proportions of nucleotides (& N's)
     pub g_s: f32,
@@ -79,6 +80,7 @@ pub fn seq_stats(dna: &[u8], masked: bool) -> SeqStats {
         gc_proportion: ((g_counts + c_counts) as f32
             / (g_counts + c_counts + a_counts + t_counts) as f32),
         gc_skew: (g_counts - c_counts) as f32 / (g_counts + c_counts) as f32,
+        at_skew: (a_counts - t_counts) as f32 / (a_counts + t_counts) as f32,
         shannon_entropy: entropy,
         g_s: ((g_counts) as f32 / length),
         c_s: ((c_counts) as f32 / length),

--- a/src/seq_statsu8.rs
+++ b/src/seq_statsu8.rs
@@ -5,6 +5,7 @@ pub struct SeqStats {
     pub gc_skew: f32,
     pub at_skew: f32,
     pub shannon_entropy: f64,
+    pub nuc_counts: Vec<i32>,
     // proportions of nucleotides (& N's)
     pub g_s: f32,
     pub c_s: f32,
@@ -82,6 +83,7 @@ pub fn seq_stats(dna: &[u8], masked: bool) -> SeqStats {
         gc_skew: (g_counts - c_counts) as f32 / (g_counts + c_counts) as f32,
         at_skew: (a_counts - t_counts) as f32 / (a_counts + t_counts) as f32,
         shannon_entropy: entropy,
+        nuc_counts: vec![a_counts, c_counts, g_counts, t_counts],
         g_s: ((g_counts) as f32 / length),
         c_s: ((c_counts) as f32 / length),
         a_s: ((a_counts) as f32 / length),

--- a/src/seq_statsu8.rs
+++ b/src/seq_statsu8.rs
@@ -83,7 +83,7 @@ pub fn seq_stats(dna: &[u8], masked: bool) -> SeqStats {
         gc_skew: (g_counts - c_counts) as f32 / (g_counts + c_counts) as f32,
         at_skew: (a_counts - t_counts) as f32 / (a_counts + t_counts) as f32,
         shannon_entropy: entropy,
-        nuc_counts: vec![a_counts, c_counts, g_counts, t_counts],
+        nuc_counts: vec![a_counts, c_counts, g_counts, t_counts, n_counts],
         g_s: ((g_counts) as f32 / length),
         c_s: ((c_counts) as f32 / length),
         a_s: ((a_counts) as f32 / length),

--- a/src/seq_statsu8.rs
+++ b/src/seq_statsu8.rs
@@ -12,6 +12,7 @@ pub struct SeqStats {
     pub a_s: f32,
     pub t_s: f32,
     pub n_s: f32,
+    pub len: f32,
 }
 // function below reveals other ambiguous bases present in assemblies, not sure
 // how to deal with those yet.
@@ -89,6 +90,7 @@ pub fn seq_stats(dna: &[u8], masked: bool) -> SeqStats {
         a_s: ((a_counts) as f32 / length),
         t_s: ((t_counts) as f32 / length),
         n_s: ((n_counts) as f32 / length),
+        len: length,
     }
 }
 


### PR DESCRIPTION
Hi Max,

Hope you're doing well in your new job :)
As I'm writing the Nextflow pipeline that runs `fasta_windows`, I found several things to change, and I thought I'd edit the software directly rather than having separate scripts.

New metrics computed:

- AT skew
- CpG proportion
- mono-nucleotide + N counts as integers in their own file, to mimic the di-, tri-, and tetra- nucleotide counts and allow any other downstream analyses to run on exact numbers.

Bugfixes:

- removed an extra `\t` in the tsv output

Changes:

- Added `_freq` to the name of the main output file so that all files are named `${output_name}_*_windows.tsv`, which is more convenient for pattern matching

Cheers,
Matthieu