### PR TITLE
handle ambiguity codes in GC and calculate masked proportion

### DIFF
--- a/src/fw.rs
+++ b/src/fw.rs
@@ -103,6 +103,7 @@ pub fn fasta_windows(
                     a_s: seq_stats.a_s,
                     t_s: seq_stats.t_s,
                     n_s: seq_stats.n_s,
+                    masked: seq_stats.masked,
                     cpg_s: ((*kmer_stats.di_freq.get(6).unwrap_or(&0) as f32) / seq_stats.len),
                     dinucleotides: kmer_stats.dinucleotides,
                     trinucleotides: kmer_stats.trinucleotides,
@@ -172,6 +173,7 @@ pub struct Entry {
     pub a_s: f32,
     pub t_s: f32,
     pub n_s: f32,
+    pub masked: f32,
     pub cpg_s: f32,
     pub dinucleotides: f64,
     pub trinucleotides: f64,
@@ -189,8 +191,8 @@ impl Output {
         let header;
 
         match description {
-            true => header = "ID\tdescription\tstart\tend\tGC_prop\tGC_skew\tAT_skew\tShannon_entropy\tProp_Gs\tProp_Cs\tProp_As\tProp_Ts\tProp_Ns\tCpG_prop\tDinucleotide_Shannon\tTrinucleotide_Shannon\tTetranucleotide_Shannon".to_string(),
-            false => header = "ID\tstart\tend\tGC_prop\tGC_skew\tAT_skew\tShannon_entropy\tProp_Gs\tProp_Cs\tProp_As\tProp_Ts\tProp_Ns\tCpG_prop\tDinucleotide_Shannon\tTrinucleotide_Shannon\tTetranucleotide_Shannon".to_string()
+            true => header = "ID\tdescription\tstart\tend\tGC_prop\tGC_skew\tAT_skew\tShannon_entropy\tProp_Gs\tProp_Cs\tProp_As\tProp_Ts\tProp_Ns\tProp_masked\tCpG_prop\tDinucleotide_Shannon\tTrinucleotide_Shannon\tTetranucleotide_Shannon".to_string(),
+            false => header = "ID\tstart\tend\tGC_prop\tGC_skew\tAT_skew\tShannon_entropy\tProp_Gs\tProp_Cs\tProp_As\tProp_Ts\tProp_Ns\tProp_masked\tCpG_prop\tDinucleotide_Shannon\tTrinucleotide_Shannon\tTetranucleotide_Shannon".to_string()
         }
 
         writeln!(file, "{}", header)?;
@@ -202,7 +204,7 @@ impl Output {
             };
             writeln!(
                 file,
-                "{}\t{}{}\t{}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}",
+                "{}\t{}{}\t{}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}",
                 i.id,
                 desc,
                 i.start,
@@ -216,6 +218,7 @@ impl Output {
                 i.a_s,
                 i.t_s,
                 i.n_s,
+                i.masked,
                 i.cpg_s,
                 i.dinucleotides,
                 i.trinucleotides,


### PR DESCRIPTION
Hi Max

As fasta_windows is being used to replace a python script in the Nextflow version of the BlobToolKit pipeline, it would be really handy to also get the masked proportion so I've made a fork to include this in the output. 

Also took the liberty of replacing all the magic numbers with byte literals so I could keep track of which bases were which and included W/S bases in the GC proportion calculation to bring it in line with the current btk implementation.

Rich